### PR TITLE
Turn off the LED

### DIFF
--- a/powermate/__init__.py
+++ b/powermate/__init__.py
@@ -113,6 +113,15 @@ class Powermate(object):
         def connect(self):
             try:
                 self.p = btle.Peripheral(self.address, iface=self.iface)
+
+                #The PowerMate bluetooth sends a connection parameter update request after 5 seconds.
+                #Only after that has been done, can the led be turned off,
+                #The led can't be turned off if anything is written before this.
+                #Turning off the led saves battery life and prevents the auto disconnect after 5 minutes.
+                time.sleep(10)
+                val = (0).to_bytes(1, byteorder='little')
+                self.p.writeCharacteristic(LED_VAL_HND, val, False)
+
                 self.p.setDelegate(self.EventDispatcher(self.handler))
                 self._enable_notification(BATTERY_CC_HND)
                 self._enable_notification(KNOB_CC_HND)


### PR DESCRIPTION
The PowerMate Bluetooth leaves the LED on at low brightness unless it's turned off, also it will automatically disconnect after about 5 minutes.
To fix this, a delay after the connect is needed, to allow the PowerMate Bluetooth to send a Connection Parameter Update Request, after that the LED_VAL_HND (0x29) should be written to 0.
Writing LED_VAL_HND (0x29) before that does not work for some reason.