### PR TITLE
Turn off the blue LED to save battery power

### DIFF
--- a/powermate/__init__.py
+++ b/powermate/__init__.py
@@ -127,8 +127,17 @@ class Powermate(object):
             while not self.kill:
                 while not self.connect():
                     time.sleep(1)
+                connect_time = time.monotonic()
+                led_on = True
                 while not self.kill:
                     try:
+                        #turn off the led to save battery power, but only after 2 seconds
+                        #otherwise the led won't turn off
+                        if led_on and (time.monotonic() - connect_time >= 2.0):
+                            print('Turning off LED');
+                            val = (0).to_bytes(1, byteorder='little')
+                            self.p.writeCharacteristic(LED_VAL_HND, val, True)
+                            led_on = False
                         if self.p.waitForNotifications(1.0):
                             continue
                     except btle.BTLEException as e:


### PR DESCRIPTION
This pull request turns off the blue LED on the Griffin PowerMate Bluetooth 2 seconds after each connect.
This saves battery power, but events are still processed during the 2 second delay, so the functionality is not affected.
The 2 second delay is needed because the LED will not turn off otherwise, this seems to be a problem with the device, as the event is still sent.